### PR TITLE
Missed some .uwg file comment corrections

### DIFF
--- a/resources/parameters/initialize_singapore.uwg
+++ b/resources/parameters/initialize_singapore.uwg
@@ -79,10 +79,10 @@ bld,
 # =================================================
 # OPTIONAL URBAN PARAMETERS
 # =================================================
-
+# If not provided, optional parameters are taken from corresponding DOE Reference building
 albRoof,,  # roof albedo (0 - 1)
-vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0-1)
-glzR,,     # Glazing Ratio. If not provided, all buildings are assumed to have 40% glazing ratio
+vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0 - 1)
+glzR,,     # Glazing Ratio (0 - 1)
 hvac,,     # HVAC TYPE; 0 = Fully Conditioned (21C-24C); 1 = Mixed Mode Natural Ventilation (19C-29C + windows open >22C); 2 = Unconditioned (windows open >22C)
 
 # =================================================

--- a/tests/parameters/initialize_beijing.uwg
+++ b/tests/parameters/initialize_beijing.uwg
@@ -79,9 +79,10 @@ bld,
 # =================================================
 # OPTIONAL URBAN PARAMETERS
 # =================================================
+# If not provided, optional parameters are taken from corresponding DOE Reference building
 albRoof,,  # roof albedo (0 - 1)
-vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0-1)
-glzR,,     # Glazing Ratio. If not provided, all buildings are assumed to have 40% glazing ratio
+vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0 - 1)
+glzR,,     # Glazing Ratio (0 - 1)
 hvac,,     # HVAC TYPE; 0 = Fully Conditioned (21C-24C); 1 = Mixed Mode Natural Ventilation (19C-29C + windows open >22C); 2 = Unconditioned (windows open >22C)
 
 # =================================================,

--- a/tests/parameters/initialize_boston.uwg
+++ b/tests/parameters/initialize_boston.uwg
@@ -79,9 +79,10 @@ bld,
 # =================================================
 # OPTIONAL URBAN PARAMETERS
 # =================================================
+# If not provided, optional parameters are taken from corresponding DOE Reference building
 albRoof,,  # roof albedo (0 - 1)
-vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0-1)
-glzR,,     # Glazing Ratio. If not provided, all buildings are assumed to have 40% glazing ratio
+vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0 - 1)
+glzR,,     # Glazing Ratio (0 - 1)
 hvac,,     # HVAC TYPE; 0 = Fully Conditioned (21C-24C); 1 = Mixed Mode Natural Ventilation (19C-29C + windows open >22C); 2 = Unconditioned (windows open >22C)
 
 # =================================================,

--- a/tests/parameters/initialize_simparam.uwg
+++ b/tests/parameters/initialize_simparam.uwg
@@ -79,9 +79,10 @@ bld,
 # =================================================
 # OPTIONAL URBAN PARAMETERS
 # =================================================
+# If not provided, optional parameters are taken from corresponding DOE Reference building
 albRoof,,  # roof albedo (0 - 1)
-vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0-1)
-glzR,,     # Glazing Ratio. If not provided, all buildings are assumed to have 40% glazing ratio
+vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0 - 1)
+glzR,,     # Glazing Ratio (0 - 1)
 hvac,,     # HVAC TYPE; 0 = Fully Conditioned (21C-24C); 1 = Mixed Mode Natural Ventilation (19C-29C + windows open >22C); 2 = Unconditioned (windows open >22C)
 
 # =================================================,

--- a/tests/parameters/initialize_singapore.uwg
+++ b/tests/parameters/initialize_singapore.uwg
@@ -81,8 +81,8 @@ bld,
 # =================================================
 # If not provided, optional parameters are taken from corresponding DOE Reference building
 albRoof,,  # roof albedo (0 - 1)
-vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0-1)
-glzR,,     # Glazing Ratio. If not provided, all buildings are assumed to have 40% glazing ratio
+vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0 - 1)
+glzR,,     # Glazing Ratio (0 - 1)
 hvac,,     # HVAC TYPE; 0 = Fully Conditioned (21C-24C); 1 = Mixed Mode Natural Ventilation (19C-29C + windows open >22C); 2 = Unconditioned (windows open >22C)
 
 # =================================================,

--- a/tests/parameters/initialize_toronto.uwg
+++ b/tests/parameters/initialize_toronto.uwg
@@ -79,9 +79,10 @@ bld,
 # =================================================
 # OPTIONAL URBAN PARAMETERS
 # =================================================
+# If not provided, optional parameters are taken from corresponding DOE Reference building
 albRoof,,  # roof albedo (0 - 1)
-vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0-1)
-glzR,,     # Glazing Ratio. If not provided, all buildings are assumed to have 40% glazing ratio
+vegRoof,,  # Fraction of the roofs covered in grass/shrubs (0 - 1)
+glzR,,     # Glazing Ratio (0 - 1)
 hvac,,     # HVAC TYPE; 0 = Fully Conditioned (21C-24C); 1 = Mixed Mode Natural Ventilation (19C-29C + windows open >22C); 2 = Unconditioned (windows open >22C)
 
 # =================================================,


### PR DESCRIPTION
Making all optional parameters empty string, so DOE Ref buildings provide default values. Clarifying that this occurs in the comments.