### PR TITLE
Address zenith = 0 edge case for critical canyon angle

### DIFF
--- a/UWG/solarcalcs.py
+++ b/UWG/solarcalcs.py
@@ -200,11 +200,14 @@ class SolarCalcs(object):
                 self.tanzen = math.tan(0.5*math.pi+1e-6);
 
         elif (abs(self.zenith) <  1e-6):
-            raise Exception("Error at sign calculation.")
-            #self.tanzen = sign(1., zenith)*math.tan(1e-6)
+            # lim x->0 tan(x) -> 0 which results in division by zero error
+            # when calculating the critical canyon angle
+            # so set tanzen to 1e-6 which will result in critical canyon angle = 90
+            self.tanzen = 1e-6
 
         else:
             self.tanzen = math.tan(self.zenith)
 
         # critical canyon angle for which solar radiation reaches the road
+        # has to do with street canyon orientation for given solar angle
         self.critOrient = math.asin(min(abs( 1./self.tanzen)/canAspect, 1. ))

--- a/UWG/utilities.py
+++ b/UWG/utilities.py
@@ -25,18 +25,6 @@ def read_csv(file_name_):
 def is_near_zero(num, eps=1e-10):
     return abs(num) < eps
 
-def sign(x):
-    """ https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.sign.html """
-    # TODO: unfinished numpy sign
-    if is_near_zero(x):
-        return 0.0
-    elif x < 0.0:
-        return -1.0
-    elif x > 0:
-        return 1.0
-    else:
-        raise Exception("Error at sign calculation.")
-
 def str2fl(x):
     """Recurses through lists and converts lists of string to float
 


### PR DESCRIPTION
As discussed here: https://github.com/ladybug-tools/urbanWeatherGen/issues/42

I set the tanzen = 1e-6, to avoid division by zero errors when the critical canyon angle is calculated. 

Also got rid of the sign() utilties method which will not be used anymore.